### PR TITLE
fix(vite): enable polling to fix HMR

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,10 @@ export default defineConfig(({ mode }) => {
     test: {
       environment: 'jsdom',
     },
+    server: {
+      watch: {
+        usePolling: true,
+      },
+    },
   };
 });


### PR DESCRIPTION
Enables polling in the Vite development server configuration. This is necessary to ensure Hot Module Replacement (HMR) works reliably in environments where file system events are not properly propagated, such as Docker containers or WSL.